### PR TITLE
Add resource requests and limits to all applications

### DIFF
--- a/applications/alaska-rcv/values.yaml
+++ b/applications/alaska-rcv/values.yaml
@@ -19,3 +19,9 @@ ingress:
 env: []
 service:
   port: 3000
+resources:
+  requests:
+    cpu: 50m
+    memory: 132Mi
+  limits:
+    memory: 132Mi

--- a/applications/argocd/values.yaml
+++ b/applications/argocd/values.yaml
@@ -36,7 +36,29 @@ server:
       nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
       nginx.ingress.kubernetes.io/cors-expose-headers: "*, X-CustomResponseHeader"
 
+controller:
+  resources:
+    requests:
+      cpu: 100m
+      memory: 303Mi
+    limits:
+      memory: 303Mi
+
+redis:
+  resources:
+    requests:
+      cpu: 50m
+      memory: 5Mi
+    limits:
+      memory: 5Mi
+
 repoServer:
+  resources:
+    requests:
+      cpu: 200m
+      memory: 142Mi
+    limits:
+      memory: 142Mi
   podLabels:
     azure.workload.identity/use: "true"
 

--- a/applications/cert-manager/values.yaml
+++ b/applications/cert-manager/values.yaml
@@ -4,3 +4,25 @@ podLabels:
 serviceAccount:
   labels:
     azure.workload.identity/use: "true"
+resources:
+  requests:
+    cpu: 50m
+    memory: 37Mi
+  limits:
+    memory: 37Mi
+
+webhook:
+  resources:
+    requests:
+      cpu: 50m
+      memory: 14Mi
+    limits:
+      memory: 14Mi
+
+cainjector:
+  resources:
+    requests:
+      cpu: 50m
+      memory: 67Mi
+    limits:
+      memory: 67Mi

--- a/applications/discord-bot/values.yaml
+++ b/applications/discord-bot/values.yaml
@@ -10,6 +10,12 @@ env:
         key: DISCORD_TOKEN
   - name: BOT_DATABASE_PATH
     value: "/tmp/ViewData.db"
+resources:
+  requests:
+    cpu: 50m
+    memory: 128Mi
+  limits:
+    memory: 128Mi
 livenessProbe:
   httpGet: null
   exec:

--- a/applications/external-dns/values.yaml
+++ b/applications/external-dns/values.yaml
@@ -1,6 +1,12 @@
 domainFilters:
   - prod.equal.vote
 policy: sync
+resources:
+  requests:
+    cpu: 50m
+    memory: 30Mi
+  limits:
+    memory: 30Mi
 serviceAccount:
   annotations:
     azure.workload.identity/client-id: 747dcea4-b636-4456-8103-95e3335192f4

--- a/applications/ingress-nginx/values.yaml
+++ b/applications/ingress-nginx/values.yaml
@@ -6,3 +6,9 @@ controller:
   ingressClassResource:
     default: true
   replicaCount: 2
+  resources:
+    requests:
+      cpu: 100m
+      memory: 67Mi
+    limits:
+      memory: 67Mi

--- a/applications/keycloak/values.yaml
+++ b/applications/keycloak/values.yaml
@@ -25,10 +25,10 @@ tls:
 
 resources:
   requests:
-    memory: 512Mi
-  limits:
     cpu: 250m
-    memory: 1024Mi
+    memory: 962Mi
+  limits:
+    memory: 962Mi
 
 postgresql:
   enabled: true
@@ -43,3 +43,10 @@ postgresql:
   metrics:
     image:
       repository: bitnamilegacy/os-shell
+  primary:
+    resources:
+      requests:
+        cpu: 50m
+        memory: 35Mi
+      limits:
+        memory: 35Mi

--- a/applications/loki/values.yaml
+++ b/applications/loki/values.yaml
@@ -1,3 +1,19 @@
+loki:
+  resources:
+    requests:
+      cpu: 100m
+      memory: 224Mi
+    limits:
+      memory: 224Mi
+
+promtail:
+  resources:
+    requests:
+      cpu: 50m
+      memory: 123Mi
+    limits:
+      memory: 123Mi
+
 grafana:
   enabled: true
   adminPassword: admin
@@ -16,3 +32,9 @@ grafana:
       - secretName: grafana-tls
         hosts:
           - logs.prod.equal.vote
+  resources:
+    requests:
+      cpu: 50m
+      memory: 165Mi
+    limits:
+      memory: 165Mi

--- a/applications/postgresql/values.yaml
+++ b/applications/postgresql/values.yaml
@@ -18,8 +18,14 @@ auth:
     userPasswordKey: "application"
     replicationPasswordKey: "replicator"
 primary:
+  resources:
+    requests:
+      cpu: 250m
+      memory: 198Mi
+    limits:
+      memory: 198Mi
 # there are some commands that cause the db to freeze up temporarily and then the liveness probe kills the pod prematurely
   livenessProbe:
-    periodSeconds: 600 
+    periodSeconds: 600
   readinessProbe:
-    periodSeconds: 600 
+    periodSeconds: 600

--- a/applications/star-server/values.yaml
+++ b/applications/star-server/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 2
 image:
   repository: ghcr.io/equal-vote/bettervoting
-  tag: "sha-0f07860"
+  tag: "sha-005ee1f"
 ingress:
   enabled: true
   annotations:
@@ -72,6 +72,12 @@ env:
         key: AZURE_STORAGE_CONNECTION_STRING
 service:
   port: 5000
+resources:
+  requests:
+    cpu: 100m
+    memory: 125Mi
+  limits:
+    memory: 125Mi
 livenessProbe:
   httpGet:
     port: 5000


### PR DESCRIPTION
## Summary
- Added resource requests and limits to all applications based on current usage with 25% buffer
- Memory requests and limits are set to the same value (no CPU limits)
- Applied to: star-server, alaska-rcv, discord-bot, keycloak, postgresql, loki/grafana/promtail, ingress-nginx, cert-manager, external-dns, argocd

Fixes #24

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured Kubernetes CPU and memory resource requests and limits across multiple applications to improve cluster stability, optimize resource efficiency, and support predictable performance scaling.
  * Updated container image version for one application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->