### PR TITLE
Add PVC restore procedure from Azure Disk Backup

### DIFF
--- a/PVC-RESTORE.md
+++ b/PVC-RESTORE.md
@@ -4,18 +4,9 @@ Procedure to restore PVCs from Azure Disk Backup snapshots after inadvertent del
 
 ## 1. Suspend ArgoCD Sync
 
-Prevent ArgoCD from detecting the manual PV/PVC changes and attempting to reconcile (even with `prune: false`, auto-sync can still cause issues):
+Prevent ArgoCD from detecting the manual PV/PVC changes and attempting to reconcile (even with `prune: false`, auto-sync can still cause issues).
 
-```bash
-APPS=("postgresql" "keycloak" "loki" "kube-prometheus-stack")
-
-for APP in "${APPS[@]}"; do
-  argocd app get "$APP" -o json | jq -r '.status.sync.status' && \
-    argocd app set "$APP" --sync-policy none
-done
-```
-
-If you don't have the `argocd` CLI, patch the Application resources directly via the ArgoCD Kubernetes API:
+These apps are multi-source, so `argocd app set` requires `--source-pos`. Use `kubectl patch` instead:
 
 ```bash
 for APP in postgresql keycloak loki kube-prometheus-stack; do
@@ -24,7 +15,7 @@ for APP in postgresql keycloak loki kube-prometheus-stack; do
 done
 ```
 
-> Re-enable sync after restore with `argocd app set <app> --sync-policy automated --auto-prune=false` or by restoring the original syncPolicy via `kubectl patch`.
+> Re-enable sync after restore by restoring the original syncPolicy, or with `argocd app set <app> --sync-policy automated --auto-prune=false --source-pos 0` for multi-source apps.
 
 ## 2. Disk to Workload Mapping
 
@@ -210,11 +201,12 @@ Once all PVCs are restored and pods are healthy, re-enable auto-sync:
 
 ```bash
 for APP in postgresql keycloak loki kube-prometheus-stack; do
-  argocd app set "$APP" --sync-policy automated --auto-prune=false
+  kubectl patch application "$APP" -n argocd --type merge \
+    -p '{"spec":{"syncPolicy":{"automated":{"prune":false,"selfHeal":true}}}}'
 done
 ```
 
-Or via `kubectl patch` (restoring the original syncPolicy from `applications/<app>/config.json`).
+The exact syncPolicy values should match what's in `applications/<app>/config.json`.
 
 ## Caveats
 

--- a/PVC-RESTORE.md
+++ b/PVC-RESTORE.md
@@ -166,14 +166,17 @@ Repeat for each original disk (3 total).
 
 ## 7. Identify Which Restored Disk Belongs to Which Workload
 
-Restored disks are offline (not attached). Mount one at a time to inspect its
-content:
+**Loki (10GiB)** is easy — it contains `chunks/`, `index/`, `wal/`
+directories. Attach it to a busybox pod as shown below and `ls`.
+
+**The two 8GiB disks** are both Bitnami PostgreSQL and have identical directory
+layouts. Attempting to `ls` the data directory won't distinguish them. Instead,
+run a temporary PostgreSQL pod that mounts the restored disk and queries the
+catalogs:
 
 ```bash
-# Create a temporary VM (or use an existing node's mount). Simpler: attach to
-# an existing node pod that has hostPath access.
+RESTORED_DISK="<restored-disk-name>"   # e.g. pvc-56229c63-...-restored
 
-# Or, inspect by creating a temporary PV/PVC + debug pod:
 cat <<EOF | kubectl apply -f -
 apiVersion: v1
 kind: PersistentVolume
@@ -181,14 +184,14 @@ metadata:
   name: pv-inspect
 spec:
   capacity:
-    storage: <SIZE>   # 8Gi for PostgreSQL disks, 10Gi for Loki
+    storage: 8Gi
   accessModes:
     - ReadWriteOnce
   persistentVolumeReclaimPolicy: Retain
   storageClassName: ""
   csi:
     driver: disk.csi.azure.com
-    volumeHandle: /subscriptions/86f3145a-48cc-4255-8757-dd3104d15e57/resourceGroups/MC_equalvote_equalvote_westus2/providers/Microsoft.Compute/disks/<restored-disk-name>
+    volumeHandle: /subscriptions/86f3145a-48cc-4255-8757-dd3104d15e57/resourceGroups/MC_equalvote_equalvote_westus2/providers/Microsoft.Compute/disks/${RESTORED_DISK}
     fsType: ext4
 ---
 apiVersion: v1
@@ -201,14 +204,14 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: <SIZE>   # must match PV capacity
+      storage: 8Gi
   volumeName: pv-inspect
   storageClassName: ""
 ---
 apiVersion: v1
 kind: Pod
 metadata:
-  name: pod-inspect
+  name: pg-inspect
   namespace: default
 spec:
   volumes:
@@ -216,21 +219,39 @@ spec:
       persistentVolumeClaim:
         claimName: pvc-inspect
   containers:
-    - name: inspect
-      image: busybox
-      command: ["sh", "-c", "ls -la /data && sleep 10"]
+    - name: postgres
+      image: bitnamilegacy/postgresql:16
+      command:
+        - /opt/bitnami/scripts/postgresql/entrypoint.sh
+        - /opt/bitnami/scripts/postgresql/run.sh
+      env:
+        - name: POSTGRESQL_USERNAME
+          value: inspect
+        - name: POSTGRESQL_PASSWORD
+          value: inspect
+        - name: POSTGRESQL_DATABASE
+          value: inspect
+        - name: POSTGRESQL_POSTGRES_PASSWORD
+          value: inspect
       volumeMounts:
         - name: data
-          mountPath: /data
+          mountPath: /bitnami/postgresql
+  restartPolicy: Never
 EOF
 
-kubectl logs pod-inspect
+kubectl wait --for=condition=ready pod/pg-inspect -n default --timeout=60s
+kubectl exec pg-inspect -n default -- psql -U postgres -c "\l"
+kubectl delete pod,pvc,pv -n default pg-inspect pvc-inspect pv-inspect
 ```
 
-**Loki** contains `chunks`, `index`, `wal` directories.
-**PostgreSQL** contains `PG_VERSION`, `base/`, `global/` directories.
+The `\l` output lists databases. Identify each disk:
 
-Once identified, clean up the inspect pod/PV/PVC.
+| `\l` output contains            | This disk belongs to             |
+| ------------------------------- | -------------------------------- |
+| `starvote`                      | PostgreSQL (`starvote`)          |
+| `bitnami_keycloak` / `keycloak` | Keycloak PostgreSQL (`keycloak`) |
+
+Repeat for the other 8GiB disk and Loki (10GiB, inspect via busybox `ls`).
 
 ## 8. Delete Current PVCs and Their Empty Disks
 

--- a/PVC-RESTORE.md
+++ b/PVC-RESTORE.md
@@ -166,16 +166,13 @@ Repeat for each original disk (3 total).
 
 ## 7. Identify Which Restored Disk Belongs to Which Workload
 
-**Loki (10GiB)** is easy — it contains `chunks/`, `index/`, `wal/`
-directories. Attach it to a busybox pod as shown below and `ls`.
+Mount the disk read-only with a busybox pod and inspect its content without
+writing anything.
 
-**The two 8GiB disks** are both Bitnami PostgreSQL and have identical directory
-layouts. Attempting to `ls` the data directory won't distinguish them. Instead,
-run a temporary PostgreSQL pod that mounts the restored disk and queries the
-catalogs:
+**Loki (10GiB):** contains `chunks/`, `index/`, `wal/` directories — just `ls`:
 
 ```bash
-RESTORED_DISK="<restored-disk-name>"   # e.g. pvc-56229c63-...-restored
+RESTORED_DISK="<loki-restored-disk-name>"
 
 cat <<EOF | kubectl apply -f -
 apiVersion: v1
@@ -184,9 +181,9 @@ metadata:
   name: pv-inspect
 spec:
   capacity:
-    storage: 8Gi
+    storage: 10Gi
   accessModes:
-    - ReadWriteOnce
+    - ReadOnlyMany
   persistentVolumeReclaimPolicy: Retain
   storageClassName: ""
   csi:
@@ -198,10 +195,71 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: pvc-inspect
-  namespace: default
 spec:
   accessModes:
-    - ReadWriteOnce
+    - ReadOnlyMany
+  resources:
+    requests:
+      storage: 10Gi
+  volumeName: pv-inspect
+  storageClassName: ""
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pg-inspect
+spec:
+  volumes:
+    - name: data
+      persistentVolumeClaim:
+        claimName: pvc-inspect
+        readOnly: true
+  containers:
+    - name: inspect
+      image: busybox
+      command: ["ls", "/data"]
+      volumeMounts:
+        - name: data
+          mountPath: /data
+          readOnly: true
+  restartPolicy: Never
+EOF
+
+kubectl logs pg-inspect
+kubectl delete pod,pvc,pv pg-inspect pvc-inspect pv-inspect
+```
+
+**PostgreSQL (8GiB):** both disks have the same directory layout, but the
+database names are embedded in the `pg_database` catalog file (`global/1260`).
+Use `strings` — no server startup, no writes:
+
+```bash
+RESTORED_DISK="<postgres-restored-disk-name>"
+
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pv-inspect
+spec:
+  capacity:
+    storage: 8Gi
+  accessModes:
+    - ReadOnlyMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""
+  csi:
+    driver: disk.csi.azure.com
+    volumeHandle: /subscriptions/86f3145a-48cc-4255-8757-dd3104d15e57/resourceGroups/MC_equalvote_equalvote_westus2/providers/Microsoft.Compute/disks/${RESTORED_DISK}
+    fsType: ext4
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc-inspect
+spec:
+  accessModes:
+    - ReadOnlyMany
   resources:
     requests:
       storage: 8Gi
@@ -212,46 +270,38 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: pg-inspect
-  namespace: default
 spec:
   volumes:
     - name: data
       persistentVolumeClaim:
         claimName: pvc-inspect
+        readOnly: true
   containers:
-    - name: postgres
-      image: bitnamilegacy/postgresql:16
+    - name: inspect
+      image: busybox
       command:
-        - /opt/bitnami/scripts/postgresql/entrypoint.sh
-        - /opt/bitnami/scripts/postgresql/run.sh
-      env:
-        - name: POSTGRESQL_USERNAME
-          value: inspect
-        - name: POSTGRESQL_PASSWORD
-          value: inspect
-        - name: POSTGRESQL_DATABASE
-          value: inspect
-        - name: POSTGRESQL_POSTGRES_PASSWORD
-          value: inspect
+        - sh
+        - -c
+        - strings /data/global/1260 | grep -v '^[0-9]*$' | sort -u
       volumeMounts:
         - name: data
-          mountPath: /bitnami/postgresql
+          mountPath: /data
+          readOnly: true
   restartPolicy: Never
 EOF
 
-kubectl wait --for=condition=ready pod/pg-inspect -n default --timeout=60s
-kubectl exec pg-inspect -n default -- psql -U postgres -c "\l"
-kubectl delete pod,pvc,pv -n default pg-inspect pvc-inspect pv-inspect
+kubectl logs pg-inspect
+kubectl delete pod,pvc,pv pg-inspect pvc-inspect pv-inspect
 ```
 
-The `\l` output lists databases. Identify each disk:
+Identify each disk from the output:
 
-| `\l` output contains            | This disk belongs to             |
-| ------------------------------- | -------------------------------- |
-| `starvote`                      | PostgreSQL (`starvote`)          |
-| `bitnami_keycloak` / `keycloak` | Keycloak PostgreSQL (`keycloak`) |
+| `strings` output contains | This disk belongs to             |
+| ------------------------- | -------------------------------- |
+| `starvote`                | PostgreSQL (`starvote`)          |
+| `bitnami_keycloak`        | Keycloak PostgreSQL (`keycloak`) |
 
-Repeat for the other 8GiB disk and Loki (10GiB, inspect via busybox `ls`).
+Repeat for the other 8GiB disk.
 
 ## 8. Delete Current PVCs and Their Empty Disks
 

--- a/PVC-RESTORE.md
+++ b/PVC-RESTORE.md
@@ -1,0 +1,225 @@
+# PVC Restore from Azure Disk Backup
+
+Procedure to restore PVCs from Azure Disk Backup snapshots after inadvertent deletion/recreation.
+
+## 1. Suspend ArgoCD Sync
+
+Prevent ArgoCD from detecting the manual PV/PVC changes and attempting to reconcile (even with `prune: false`, auto-sync can still cause issues):
+
+```bash
+APPS=("postgresql" "keycloak" "loki" "kube-prometheus-stack")
+
+for APP in "${APPS[@]}"; do
+  argocd app get "$APP" -o json | jq -r '.status.sync.status' && \
+    argocd app set "$APP" --sync-policy none
+done
+```
+
+If you don't have the `argocd` CLI, patch the Application resources directly via the ArgoCD Kubernetes API:
+
+```bash
+for APP in postgresql keycloak loki kube-prometheus-stack; do
+  kubectl patch application "$APP" -n argocd --type merge \
+    -p '{"spec":{"syncPolicy":null}}'
+done
+```
+
+> Re-enable sync after restore with `argocd app set <app> --sync-policy automated --auto-prune=false` or by restoring the original syncPolicy via `kubectl patch`.
+
+## 2. Disk to Workload Mapping
+
+Run this in the cluster to map Azure disk IDs to PVCs:
+
+```bash
+kubectl get pv -o json | jq -r '
+  .items[] | select(.spec.azureDisk or .spec.csi.driver == "disk.csi.azure.com") |
+  "\(.metadata.name) → \(.spec.claimRef.namespace)/\(.spec.claimRef.name)  size=\(.spec.capacity.storage)"'
+```
+
+Expected mapping (from repo config):
+
+| Disk UUID                                  | Workload                    | Namespace  | PVC Name (Bitnami pattern) | Size |
+| ------------------------------------------ | --------------------------- | ---------- | -------------------------- | ---- |
+| `pvc-3cd6e8ba-fb7f-4031-a69d-e5cd96e8efba` | PostgreSQL (starvote)       | `starvote` | `data-postgresql-0`        | 8Gi  |
+| `pvc-56229c63-fd75-49d0-8f6b-7ce7d107bc68` | Keycloak bundled PostgreSQL | `keycloak` | `data-postgresql-0`        | 8Gi  |
+| `pvc-7d5e2740-7f0a-4115-acbe-b84975edf773` | Loki                        | `loki`     | `loki-<statefulset>-0`     | 10Gi |
+
+> Verify PVC names with `kubectl get pvc -A` — Bitnami charts name PVCs `data-<release>-<replica>-0`.
+
+## 3. Find the Latest Recovery Point
+
+```bash
+DISKS=(
+  "pvc-3cd6e8ba-fb7f-4031-a69d-e5cd96e8efba"
+  "pvc-56229c63-fd75-49d0-8f6b-7ce7d107bc68"
+  "pvc-7d5e2740-7f0a-4115-acbe-b84975edf773"
+)
+
+for DISK in "${DISKS[@]}"; do
+  echo "=== $DISK ==="
+  az backup recoverypoint list \
+    --vault-name equalvote-backup-vault \
+    --resource-group equalvote \
+    --backup-management-type AzureWorkload \
+    --container-name "$DISK" \
+    --query "max_by([], &properties.recoveryPointTime).{name:name, time:properties.recoveryPointTime}" \
+    -o tsv
+done
+```
+
+## 4. Restore a Disk from Snapshot
+
+For each disk to restore, create a new managed disk from the latest recovery point:
+
+```bash
+DISK_NAME="pvc-3cd6e8ba-fb7f-4031-a69d-e5cd96e8efba"
+RP_ID="<recovery-point-name-from-above>"
+RESTORED_DISK_NAME="${DISK_NAME}-restored"
+NODE_RG="MC_equalvote_equalvote_westus2"
+
+az backup restore restore-disks \
+  --vault-name equalvote-backup-vault \
+  --resource-group equalvote \
+  --container-name "$DISK_NAME" \
+  --item-name "$DISK_NAME" \
+  --rp-name "$RP_ID" \
+  --target-resource-group "$NODE_RG" \
+  --storage-account "" \
+  --restore-to-managed-disk \
+  --disk-name "$RESTORED_DISK_NAME"
+```
+
+This creates a disk named `pvc-<uuid>-restored` in `MC_equalvote_equalvote_westus2`.
+
+## 5. Create PV + PVC Backed by Restored Disk
+
+**PostgreSQL (starvote):**
+
+```yaml
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pv-restored-postgresql
+spec:
+  capacity:
+    storage: 8Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: managed-csi
+  csi:
+    driver: disk.csi.azure.com
+    volumeHandle: /subscriptions/86f3145a-48cc-4255-8757-dd3104d15e57/resourceGroups/MC_equalvote_equalvote_westus2/providers/Microsoft.Compute/disks/pvc-3cd6e8ba-fb7f-4031-a69d-e5cd96e8efba-restored
+    fsType: ext4
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: data-postgresql-0
+  namespace: starvote
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 8Gi
+  volumeName: pv-restored-postgresql
+  storageClassName: ""
+```
+
+**Keycloak PostgreSQL:**
+
+```yaml
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pv-restored-keycloak-postgresql
+spec:
+  capacity:
+    storage: 8Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: managed-csi
+  csi:
+    driver: disk.csi.azure.com
+    volumeHandle: /subscriptions/86f3145a-48cc-4255-8757-dd3104d15e57/resourceGroups/MC_equalvote_equalvote_westus2/providers/Microsoft.Compute/disks/pvc-56229c63-fd75-49d0-8f6b-7ce7d107bc68-restored
+    fsType: ext4
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: data-postgresql-0
+  namespace: keycloak
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 8Gi
+  volumeName: pv-restored-keycloak-postgresql
+  storageClassName: ""
+```
+
+**Loki:**
+
+```yaml
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pv-restored-loki
+spec:
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: managed-csi
+  csi:
+    driver: disk.csi.azure.com
+    volumeHandle: /subscriptions/86f3145a-48cc-4255-8757-dd3104d15e57/resourceGroups/MC_equalvote_equalvote_westus2/providers/Microsoft.Compute/disks/pvc-7d5e2740-7f0a-4115-acbe-b84975edf773-restored
+    fsType: ext4
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: loki-<statefulset>-0  # replace with actual name from `kubectl get pvc -n loki`
+  namespace: loki
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  volumeName: pv-restored-loki
+  storageClassName: ""
+```
+
+Apply and restart the pod:
+
+```bash
+kubectl apply -f restore-<workload>.yaml
+kubectl delete pod -n <namespace> <pod-name>
+```
+
+The pod will re-create and pick up the restored PV.
+
+## 6. Re-enable ArgoCD Sync
+
+Once all PVCs are restored and pods are healthy, re-enable auto-sync:
+
+```bash
+for APP in postgresql keycloak loki kube-prometheus-stack; do
+  argocd app set "$APP" --sync-policy automated --auto-prune=false
+done
+```
+
+Or via `kubectl patch` (restoring the original syncPolicy from `applications/<app>/config.json`).
+
+## Caveats
+
+- **Crash-consistent snapshots.** Azure Disk Backup does not quiesce the filesystem. PostgreSQL data may require WAL replay on startup, which usually succeeds. For critical restores, consider `pg_start_backup()` / `pg_stop_backup()` during the backup window.
+- **Region / zone.** Restored disks land in the same region (West US 2). If your AKS node pool uses availability zones, you may need to specify a zone in the restore command or create the PV with a `topology` constraint.
+- **Orphaned disks.** If the PVC was re-created by Helm, the old disk (with original data) still exists in `MC_equalvote_equalvote_westus2` but is no longer bound. Verify which disk is current before restoring.
+- **Retain policy.** The PV uses `persistentVolumeReclaimPolicy: Retain` to prevent accidental deletion.
+- **`storageClassName: ""`** on the PVC is required to bind to an existing PV.

--- a/PVC-RESTORE.md
+++ b/PVC-RESTORE.md
@@ -56,85 +56,111 @@ Record the PV names — you need to delete them (they point to the empty disks).
 
 ## 4. Identify Original (Deleted) Disks in the Backup Vault
 
-The backup instances are named after the original disk UUIDs. List them all:
+The vault (`equalvote-backup-vault`) is a Data Protection backup vault — use
+`az dataprotection` commands, not `az backup`.
+
+List all backup instances (named after the original disk UUIDs):
 
 ```bash
-az backup container list \
+az dataprotection backup-instance list \
   --vault-name equalvote-backup-vault \
   --resource-group equalvote \
-  --backup-management-type AzureWorkload \
-  --query "[].{name:name, status:properties.healthStatus}" \
+  --query "[].{name:name, status:properties.currentProtectionState}" \
   -o table
 ```
 
-For each container (disk), list its recovery points and disk size:
+Expected output — three original disks that were being backed up before deletion:
 
-```bash
-az backup recoverypoint list \
-  --vault-name equalvote-backup-vault \
-  --resource-group equalvote \
-  --backup-management-type AzureWorkload \
-  --container-name "<disk-name>" \
-  --item-name "<disk-name>" \
-  --query "[*].{rp:name, time:properties.recoveryPointTime, size:properties.recoveryPointSizeInBytes}" \
-  -o table
+```
+Name                                      Status
+----------------------------------------  --------------------
+pvc-3cd6e8ba-fb7f-4031-a69d-e5cd96e8efba  ProtectionConfigured
+pvc-56229c63-fd75-49d0-8f6b-7ce7d107bc68  ProtectionConfigured
+pvc-7d5e2740-7f0a-4115-acbe-b84975edf773  ProtectionConfigured
 ```
 
-Get only the latest recovery point per disk:
+For each backup instance, find the latest recovery point and the disk size
+(stored as JSON in the recovery point metadata):
 
 ```bash
-for CONTAINER in $(az backup container list \
+for INSTANCE in $(az dataprotection backup-instance list \
   --vault-name equalvote-backup-vault \
   --resource-group equalvote \
-  --backup-management-type AzureWorkload \
   --query "[].name" -o tsv); do
 
-  echo "=== $CONTAINER ==="
-  az backup recoverypoint list \
+  RP_ID=$(az dataprotection recovery-point list \
+    --backup-instance-name "$INSTANCE" \
     --vault-name equalvote-backup-vault \
     --resource-group equalvote \
-    --backup-management-type AzureWorkload \
-    --container-name "$CONTAINER" \
-    --item-name "$CONTAINER" \
-    --query "max_by([], &properties.recoveryPointTime).{rp:name, time:properties.recoveryPointTime, size:properties.recoveryPointSizeInBytes}" \
-    -o tsv
+    --query "max_by([], &properties.recoveryPointTime).name" -o tsv)
+
+  META=$(az dataprotection recovery-point show \
+    --backup-instance-name "$INSTANCE" \
+    --vault-name equalvote-backup-vault \
+    --resource-group equalvote \
+    --recovery-point-id "$RP_ID" \
+    --query "properties.recoveryPointDataStoresDetails[0].metaData" -o tsv)
+
+  SIZE=$(echo "$META" | python3 -c "
+import sys, json
+d = json.loads(sys.stdin.read())[0]
+print(f\"{d['sizeBytes'] / 1024**3:.0f}GiB\")
+")
+
+  echo "$INSTANCE  latest=$RP_ID  size=$SIZE"
 done
 ```
 
 ## 5. Map Original Disks to Workloads by Size
 
-Use the recovery point size (or original disk size) to identify each disk:
+The recovery point metadata reveals the disk size. Use it to identify each
+workload:
 
-- **10 GiB** → Loki (`loki`)
-- **8 GiB** → PostgreSQL or Keycloak PostgreSQL
+| Size  | Workload                    | Namespace  |
+| ----- | --------------------------- | ---------- |
+| 8GiB  | PostgreSQL (starvote)       | `starvote` |
+| 8GiB  | Keycloak bundled PostgreSQL | `keycloak` |
+| 10GiB | Loki                        | `loki`     |
 
-For the two 8 GiB disks, distinguish them after restoring (see step 7), or
-check the volume label/uuid against the cluster's old PV records.
+> The two 8GiB disks are both Bitnami PostgreSQL and cannot be distinguished by
+> size alone. After restoring one, mount it to inspect (step 7) — **PostgreSQL**
+> contains `PG_VERSION`, `base/`, `global/`; **Keycloak** contains a `keycloak`
+> database in `base/`.
 
 ## 6. Restore a Disk from Snapshot
 
-For each original disk, create a new managed disk from its latest recovery
-point:
+For each original disk, restore its latest recovery point to a new managed disk.
+The Data Protection API uses a two-step process: initialize the restore request
+JSON, then trigger the restore.
 
 ```bash
-DISK_NAME="<original-disk-uuid-from-step-4>"
-RP_ID="<latest-rp-name-from-step-4>"
-RESTORED_DISK_NAME="${DISK_NAME}-restored"
-NODE_RG="MC_equalvote_equalvote_westus2"
+INSTANCE="<original-disk-uuid-from-step-4>"
+RP_ID="<latest-rp-id-from-step-4>"
+RESTORED_NAME="${INSTANCE}-restored"
 
-az backup restore restore-disks \
+# 1) Generate the restore request body
+RESTORE_REQUEST=$(az dataprotection backup-instance restore initialize-for-data-recovery \
+  --datasource-type AzureDisk \
+  --restore-location westus2 \
+  --source-datastore OperationalStore \
+  --recovery-point-id "$RP_ID" \
+  --target-resource-id "/subscriptions/86f3145a-48cc-4255-8757-dd3104d15e57/resourceGroups/MC_equalvote_equalvote_westus2/providers/Microsoft.Compute/disks/$RESTORED_NAME")
+
+# 2) Trigger the restore (--no-wait returns immediately)
+az dataprotection backup-instance restore trigger \
+  --name "$INSTANCE" \
   --vault-name equalvote-backup-vault \
   --resource-group equalvote \
-  --container-name "$DISK_NAME" \
-  --item-name "$DISK_NAME" \
-  --rp-name "$RP_ID" \
-  --target-resource-group "$NODE_RG" \
-  --storage-account "" \
-  --restore-to-managed-disk \
-  --disk-name "$RESTORED_DISK_NAME"
+  --restore-request-object "$RESTORE_REQUEST" \
+  --no-wait
 ```
 
-This creates a disk named `pvc-<uuid>-restored` in `MC_equalvote_equalvote_westus2`.
+This creates a disk named `pvc-<uuid>-restored` in
+`MC_equalvote_equalvote_westus2`. Check progress with:
+
+```bash
+az disk show -g MC_equalvote_equalvote_westus2 -n "$RESTORED_NAME" --query provisioningState
+```
 
 Repeat for each original disk (3 total).
 
@@ -155,7 +181,7 @@ metadata:
   name: pv-inspect
 spec:
   capacity:
-    storage: 10Gi     # match restored disk size
+    storage: <SIZE>   # 8Gi for PostgreSQL disks, 10Gi for Loki
   accessModes:
     - ReadWriteOnce
   persistentVolumeReclaimPolicy: Retain
@@ -175,7 +201,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 10Gi
+      storage: <SIZE>   # must match PV capacity
   volumeName: pv-inspect
   storageClassName: ""
 ---

--- a/PVC-RESTORE.md
+++ b/PVC-RESTORE.md
@@ -337,7 +337,7 @@ spec:
   accessModes:
     - ReadWriteOnce
   persistentVolumeReclaimPolicy: Retain
-  storageClassName: managed-csi
+  storageClassName: ""
   csi:
     driver: disk.csi.azure.com
     volumeHandle: /subscriptions/86f3145a-48cc-4255-8757-dd3104d15e57/resourceGroups/MC_equalvote_equalvote_westus2/providers/Microsoft.Compute/disks/<restored-disk-uuid-for-postgresql>
@@ -371,7 +371,7 @@ spec:
   accessModes:
     - ReadWriteOnce
   persistentVolumeReclaimPolicy: Retain
-  storageClassName: managed-csi
+  storageClassName: ""
   csi:
     driver: disk.csi.azure.com
     volumeHandle: /subscriptions/86f3145a-48cc-4255-8757-dd3104d15e57/resourceGroups/MC_equalvote_equalvote_westus2/providers/Microsoft.Compute/disks/<restored-disk-uuid-for-keycloak>
@@ -405,7 +405,7 @@ spec:
   accessModes:
     - ReadWriteOnce
   persistentVolumeReclaimPolicy: Retain
-  storageClassName: managed-csi
+  storageClassName: ""
   csi:
     driver: disk.csi.azure.com
     volumeHandle: /subscriptions/86f3145a-48cc-4255-8757-dd3104d15e57/resourceGroups/MC_equalvote_equalvote_westus2/providers/Microsoft.Compute/disks/<restored-disk-uuid-for-loki>

--- a/PVC-RESTORE.md
+++ b/PVC-RESTORE.md
@@ -1,12 +1,15 @@
 # PVC Restore from Azure Disk Backup
 
-Procedure to restore PVCs from Azure Disk Backup snapshots after inadvertent deletion/recreation.
+Procedure to restore PVCs from Azure Disk Backup snapshots after PVCs were
+deleted and re-created, leaving new empty disks in place.
+
+The backup vault (`equalvote-backup-vault`) still holds recovery points for the
+**original** (deleted) disks — those are what we restore.
 
 ## 1. Suspend ArgoCD Sync
 
-Prevent ArgoCD from detecting the manual PV/PVC changes and attempting to reconcile (even with `prune: false`, auto-sync can still cause issues).
-
-These apps are multi-source, so `argocd app set` requires `--source-pos`. Use `kubectl patch` instead:
+Prevent ArgoCD from reconciling during the restore. These apps are multi-source,
+so use `kubectl patch`:
 
 ```bash
 for APP in postgresql keycloak loki kube-prometheus-stack; do
@@ -15,56 +18,107 @@ for APP in postgresql keycloak loki kube-prometheus-stack; do
 done
 ```
 
-> Re-enable sync after restore by restoring the original syncPolicy, or with `argocd app set <app> --sync-policy automated --auto-prune=false --source-pos 0` for multi-source apps.
+> Re-enable later with `--sync-policy automated --auto-prune=false --source-pos 0`.
 
-## 2. Disk to Workload Mapping
+## 2. Scale Down Workloads
 
-Run this in the cluster to map Azure disk IDs to PVCs:
+Stop pods so PVCs can be swapped:
 
 ```bash
-kubectl get pv -o json | jq -r '
-  .items[] | select(.spec.azureDisk or .spec.csi.driver == "disk.csi.azure.com") |
-  "\(.metadata.name) → \(.spec.claimRef.namespace)/\(.spec.claimRef.name)  size=\(.spec.capacity.storage)"'
+kubectl scale statefulset -n starvote postgresql --replicas=0
+kubectl scale statefulset -n keycloak keycloak-postgresql --replicas=0
+kubectl scale statefulset -n loki loki --replicas=0
 ```
 
-Expected mapping (from repo config):
+> Scale back up after restore.
 
-| Disk UUID                                  | Workload                    | Namespace  | PVC Name (Bitnami pattern) | Size |
-| ------------------------------------------ | --------------------------- | ---------- | -------------------------- | ---- |
-| `pvc-3cd6e8ba-fb7f-4031-a69d-e5cd96e8efba` | PostgreSQL (starvote)       | `starvote` | `data-postgresql-0`        | 8Gi  |
-| `pvc-56229c63-fd75-49d0-8f6b-7ce7d107bc68` | Keycloak bundled PostgreSQL | `keycloak` | `data-postgresql-0`        | 8Gi  |
-| `pvc-7d5e2740-7f0a-4115-acbe-b84975edf773` | Loki                        | `loki`     | `loki-<statefulset>-0`     | 10Gi |
+## 3. List Current PVCs and Their New (Empty) Disk IDs
 
-> Verify PVC names with `kubectl get pvc -A` — Bitnami charts name PVCs `data-<release>-<replica>-0`.
-
-## 3. Find the Latest Recovery Point
+Identify the empty PVCs that need to be replaced:
 
 ```bash
-DISKS=(
-  "pvc-3cd6e8ba-fb7f-4031-a69d-e5cd96e8efba"
-  "pvc-56229c63-fd75-49d0-8f6b-7ce7d107bc68"
-  "pvc-7d5e2740-7f0a-4115-acbe-b84975edf773"
-)
+kubectl get pvc -A -o custom-columns=\
+NAMESPACE:.metadata.namespace,\
+NAME:.metadata.name,\
+SIZE:.spec.resources.requests.storage,\
+VOLUME:.spec.volumeName
+```
 
-for DISK in "${DISKS[@]}"; do
-  echo "=== $DISK ==="
+Expected empty PVCs:
+
+| Namespace  | PVC Name            | Size | PV (auto-provisioned) |
+| ---------- | ------------------- | ---- | --------------------- |
+| `starvote` | `data-postgresql-0` | 8Gi  | `pvc-<new-uuid>`      |
+| `keycloak` | `data-postgresql-0` | 8Gi  | `pvc-<new-uuid>`      |
+| `loki`     | `data-loki-0`       | 10Gi | `pvc-<new-uuid>`      |
+
+Record the PV names — you need to delete them (they point to the empty disks).
+
+## 4. Identify Original (Deleted) Disks in the Backup Vault
+
+The backup instances are named after the original disk UUIDs. List them all:
+
+```bash
+az backup container list \
+  --vault-name equalvote-backup-vault \
+  --resource-group equalvote \
+  --backup-management-type AzureWorkload \
+  --query "[].{name:name, status:properties.healthStatus}" \
+  -o table
+```
+
+For each container (disk), list its recovery points and disk size:
+
+```bash
+az backup recoverypoint list \
+  --vault-name equalvote-backup-vault \
+  --resource-group equalvote \
+  --backup-management-type AzureWorkload \
+  --container-name "<disk-name>" \
+  --item-name "<disk-name>" \
+  --query "[*].{rp:name, time:properties.recoveryPointTime, size:properties.recoveryPointSizeInBytes}" \
+  -o table
+```
+
+Get only the latest recovery point per disk:
+
+```bash
+for CONTAINER in $(az backup container list \
+  --vault-name equalvote-backup-vault \
+  --resource-group equalvote \
+  --backup-management-type AzureWorkload \
+  --query "[].name" -o tsv); do
+
+  echo "=== $CONTAINER ==="
   az backup recoverypoint list \
     --vault-name equalvote-backup-vault \
     --resource-group equalvote \
     --backup-management-type AzureWorkload \
-    --container-name "$DISK" \
-    --query "max_by([], &properties.recoveryPointTime).{name:name, time:properties.recoveryPointTime}" \
+    --container-name "$CONTAINER" \
+    --item-name "$CONTAINER" \
+    --query "max_by([], &properties.recoveryPointTime).{rp:name, time:properties.recoveryPointTime, size:properties.recoveryPointSizeInBytes}" \
     -o tsv
 done
 ```
 
-## 4. Restore a Disk from Snapshot
+## 5. Map Original Disks to Workloads by Size
 
-For each disk to restore, create a new managed disk from the latest recovery point:
+Use the recovery point size (or original disk size) to identify each disk:
+
+- **10 GiB** → Loki (`loki`)
+- **8 GiB** → PostgreSQL or Keycloak PostgreSQL
+
+For the two 8 GiB disks, distinguish them after restoring (see step 7), or
+check the volume label/uuid against the cluster's old PV records.
+
+## 6. Restore a Disk from Snapshot
+
+For each original disk, create a new managed disk from its latest recovery
+point:
 
 ```bash
-DISK_NAME="pvc-3cd6e8ba-fb7f-4031-a69d-e5cd96e8efba"
-RP_ID="<recovery-point-name-from-above>"
+DISK_NAME="<original-disk-uuid-from-step-4>"
+RP_ID="<latest-rp-name-from-step-4>"
 RESTORED_DISK_NAME="${DISK_NAME}-restored"
 NODE_RG="MC_equalvote_equalvote_westus2"
 
@@ -82,7 +136,96 @@ az backup restore restore-disks \
 
 This creates a disk named `pvc-<uuid>-restored` in `MC_equalvote_equalvote_westus2`.
 
-## 5. Create PV + PVC Backed by Restored Disk
+Repeat for each original disk (3 total).
+
+## 7. Identify Which Restored Disk Belongs to Which Workload
+
+Restored disks are offline (not attached). Mount one at a time to inspect its
+content:
+
+```bash
+# Create a temporary VM (or use an existing node's mount). Simpler: attach to
+# an existing node pod that has hostPath access.
+
+# Or, inspect by creating a temporary PV/PVC + debug pod:
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pv-inspect
+spec:
+  capacity:
+    storage: 10Gi     # match restored disk size
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""
+  csi:
+    driver: disk.csi.azure.com
+    volumeHandle: /subscriptions/86f3145a-48cc-4255-8757-dd3104d15e57/resourceGroups/MC_equalvote_equalvote_westus2/providers/Microsoft.Compute/disks/<restored-disk-name>
+    fsType: ext4
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc-inspect
+  namespace: default
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  volumeName: pv-inspect
+  storageClassName: ""
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-inspect
+  namespace: default
+spec:
+  volumes:
+    - name: data
+      persistentVolumeClaim:
+        claimName: pvc-inspect
+  containers:
+    - name: inspect
+      image: busybox
+      command: ["sh", "-c", "ls -la /data && sleep 10"]
+      volumeMounts:
+        - name: data
+          mountPath: /data
+EOF
+
+kubectl logs pod-inspect
+```
+
+**Loki** contains `chunks`, `index`, `wal` directories.
+**PostgreSQL** contains `PG_VERSION`, `base/`, `global/` directories.
+
+Once identified, clean up the inspect pod/PV/PVC.
+
+## 8. Delete Current PVCs and Their Empty Disks
+
+For each workload, delete the current PVC (which cascades to delete the empty
+Azure disk — the CSI driver's default reclaim policy is Delete):
+
+```bash
+# Delete PVCs (this also deletes the empty Azure disks)
+kubectl delete pvc -n starvote data-postgresql-0
+kubectl delete pvc -n keycloak data-postgresql-0
+kubectl delete pvc -n loki data-loki-0
+
+# Delete the orphaned PVs that were bound to those PVCs
+kubectl delete pv <pv-name-from-step-3>     # starvote postgresql
+kubectl delete pv <pv-name-from-step-3>     # keycloak postgresql
+kubectl delete pv <pv-name-from-step-3>     # loki
+```
+
+> Confirm the empty Azure disks are gone: `az disk list -g MC_equalvote_equalvote_westus2 --query "[].name" -o table`
+
+## 9. Create New PVs Backed by Restored Disks
 
 **PostgreSQL (starvote):**
 
@@ -100,7 +243,7 @@ spec:
   storageClassName: managed-csi
   csi:
     driver: disk.csi.azure.com
-    volumeHandle: /subscriptions/86f3145a-48cc-4255-8757-dd3104d15e57/resourceGroups/MC_equalvote_equalvote_westus2/providers/Microsoft.Compute/disks/pvc-3cd6e8ba-fb7f-4031-a69d-e5cd96e8efba-restored
+    volumeHandle: /subscriptions/86f3145a-48cc-4255-8757-dd3104d15e57/resourceGroups/MC_equalvote_equalvote_westus2/providers/Microsoft.Compute/disks/<restored-disk-uuid-for-postgresql>
     fsType: ext4
 ---
 apiVersion: v1
@@ -134,7 +277,7 @@ spec:
   storageClassName: managed-csi
   csi:
     driver: disk.csi.azure.com
-    volumeHandle: /subscriptions/86f3145a-48cc-4255-8757-dd3104d15e57/resourceGroups/MC_equalvote_equalvote_westus2/providers/Microsoft.Compute/disks/pvc-56229c63-fd75-49d0-8f6b-7ce7d107bc68-restored
+    volumeHandle: /subscriptions/86f3145a-48cc-4255-8757-dd3104d15e57/resourceGroups/MC_equalvote_equalvote_westus2/providers/Microsoft.Compute/disks/<restored-disk-uuid-for-keycloak>
     fsType: ext4
 ---
 apiVersion: v1
@@ -168,13 +311,13 @@ spec:
   storageClassName: managed-csi
   csi:
     driver: disk.csi.azure.com
-    volumeHandle: /subscriptions/86f3145a-48cc-4255-8757-dd3104d15e57/resourceGroups/MC_equalvote_equalvote_westus2/providers/Microsoft.Compute/disks/pvc-7d5e2740-7f0a-4115-acbe-b84975edf773-restored
+    volumeHandle: /subscriptions/86f3145a-48cc-4255-8757-dd3104d15e57/resourceGroups/MC_equalvote_equalvote_westus2/providers/Microsoft.Compute/disks/<restored-disk-uuid-for-loki>
     fsType: ext4
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: loki-<statefulset>-0  # replace with actual name from `kubectl get pvc -n loki`
+  name: data-loki-0
   namespace: loki
 spec:
   accessModes:
@@ -186,18 +329,29 @@ spec:
   storageClassName: ""
 ```
 
-Apply and restart the pod:
+Apply them:
 
 ```bash
-kubectl apply -f restore-<workload>.yaml
-kubectl delete pod -n <namespace> <pod-name>
+kubectl apply -f restored-pvcs.yaml
 ```
 
-The pod will re-create and pick up the restored PV.
+## 10. Scale Workloads Back Up
 
-## 6. Re-enable ArgoCD Sync
+```bash
+kubectl scale statefulset -n starvote postgresql --replicas=1
+kubectl scale statefulset -n keycloak keycloak-postgresql --replicas=1
+kubectl scale statefulset -n loki loki --replicas=1
+```
 
-Once all PVCs are restored and pods are healthy, re-enable auto-sync:
+Verify each pod mounts the restored PVC and starts without errors:
+
+```bash
+kubectl logs -n starvote postgresql-0 --tail=20
+kubectl logs -n keycloak keycloak-postgresql-0 --tail=20
+kubectl logs -n loki loki-0 --tail=20
+```
+
+## 11. Re-enable ArgoCD Sync
 
 ```bash
 for APP in postgresql keycloak loki kube-prometheus-stack; do
@@ -206,12 +360,15 @@ for APP in postgresql keycloak loki kube-prometheus-stack; do
 done
 ```
 
-The exact syncPolicy values should match what's in `applications/<app>/config.json`.
-
 ## Caveats
 
-- **Crash-consistent snapshots.** Azure Disk Backup does not quiesce the filesystem. PostgreSQL data may require WAL replay on startup, which usually succeeds. For critical restores, consider `pg_start_backup()` / `pg_stop_backup()` during the backup window.
-- **Region / zone.** Restored disks land in the same region (West US 2). If your AKS node pool uses availability zones, you may need to specify a zone in the restore command or create the PV with a `topology` constraint.
-- **Orphaned disks.** If the PVC was re-created by Helm, the old disk (with original data) still exists in `MC_equalvote_equalvote_westus2` but is no longer bound. Verify which disk is current before restoring.
-- **Retain policy.** The PV uses `persistentVolumeReclaimPolicy: Retain` to prevent accidental deletion.
+- **Crash-consistent snapshots.** Azure Disk Backup does not quiesce the
+  filesystem. PostgreSQL may require WAL replay on startup; this usually
+  succeeds but verify logs.
+- **Region / zone.** Restored disks land in the same region (West US 2). If
+  your AKS node pool uses availability zones, specify one or add a topology
+  constraint to the PV.
+- **Reclaim policy.** The PV uses `Retain` to prevent accidental deletion.
 - **`storageClassName: ""`** on the PVC is required to bind to an existing PV.
+- **StatefulSet PVC naming.** Bitnami PostgreSQL creates PVCs named
+  `data-<release>-0`. Confirm the exact name with `kubectl get pvc -A`.

--- a/PVC-RESTORE.md
+++ b/PVC-RESTORE.md
@@ -183,7 +183,7 @@ spec:
   capacity:
     storage: 10Gi
   accessModes:
-    - ReadOnlyMany
+    - ReadWriteOnce
   persistentVolumeReclaimPolicy: Retain
   storageClassName: ""
   csi:
@@ -197,7 +197,7 @@ metadata:
   name: pvc-inspect
 spec:
   accessModes:
-    - ReadOnlyMany
+    - ReadWriteOnce
   resources:
     requests:
       storage: 10Gi
@@ -245,7 +245,7 @@ spec:
   capacity:
     storage: 8Gi
   accessModes:
-    - ReadOnlyMany
+    - ReadWriteOnce
   persistentVolumeReclaimPolicy: Retain
   storageClassName: ""
   csi:
@@ -259,7 +259,7 @@ metadata:
   name: pvc-inspect
 spec:
   accessModes:
-    - ReadOnlyMany
+    - ReadWriteOnce
   resources:
     requests:
       storage: 8Gi


### PR DESCRIPTION
Step-by-step restore procedure for PVCs from Azure Disk Backup snapshots, including:\n- Suspend ArgoCD sync\n- Map disks to workloads\n- Find latest recovery points\n- Restore disks from snapshot\n- Create PV+PVC bindings\n- Re-enable ArgoCD sync

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a runbook for restoring persistent volumes from Azure Disk backup snapshots after accidental PVC deletion/recreation. Includes step‑by‑step guidance: pause reconciliation, map disks to claims, find recovery points, restore disks via CLI, recreate PV/PVC for affected services, apply manifests and restart pods.
  * Notes operational caveats: crash‑consistency/WAL replay, region/zone limits, orphaned disks, Retain reclaim policy, and empty storageClassName requirement.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Equal-Vote/argocd/pull/37?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->