### PR TITLE
Include fider-secrets.enc.yaml in ksops secret generator

### DIFF
--- a/secrets/secret-generator.yaml
+++ b/secrets/secret-generator.yaml
@@ -4,3 +4,4 @@ metadata:
   name: "secret-generator"
 files:
   - "./secrets.enc.yaml"
+  - "./fider-secrets.enc.yaml"


### PR DESCRIPTION
## Context

I seeing the following error after deployment

```
container "app" in pod "fider-64d659b76-m2ff9" is waiting to start: CreateContainerConfigError
```

After checking kubectl I confirmed that the fider secret wasn't present

```
$ kubectl get secret -n fider
NAME                   TYPE                       DATA   AGE
fider-db-app           kubernetes.io/basic-auth   11     3h6m
fider-db-ca            Opaque                     2      3h6m
fider-db-replication   kubernetes.io/tls          2      3h6m
fider-db-server        kubernetes.io/tls          2      3h6m
fider-db-superuser     kubernetes.io/basic-auth   11     3h6m
fider-tls              kubernetes.io/tls          2      3h4m
```

## Summary
- `secrets/fider-secrets.enc.yaml` was added in c417db5 (JWT_SECRET, DATABASE_URL, EMAIL_SMTP_PASSWORD for Fider) but never added to the ksops generator's `files` list in `secrets/secret-generator.yaml`.
- As a result, the `fider` secret was never generated in the cluster, and the Fider pod fails with `CreateContainerConfigError` because its env vars reference `secretKeyRef: fider`, which doesn't exist.

## Test plan
- [ ] Merge and let ArgoCD sync the `secrets` app
- [ ] Confirm `kubectl get secret -n fider fider` now exists
- [ ] Confirm the Fider pod starts successfully and no longer shows `CreateContainerConfigError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an additional encrypted secrets file to the application’s secret configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->