### PR TITLE
Disable KubeClientErrors alert

### DIFF
--- a/applications/kube-prometheus-stack/values.yaml
+++ b/applications/kube-prometheus-stack/values.yaml
@@ -9,6 +9,18 @@ kubeScheduler:
 kubeProxy:
   enabled: false
 
+defaultRules:
+  disabled:
+    # AKS puts its apiserver replicas behind a single load-balanced endpoint, so all
+    # of them report as one Prometheus series and their rest_client_requests_total
+    # counters interleave. Every scrape that lands on a replica with a lower counter
+    # than the previous scrape looks like a counter reset, so rate() invents traffic
+    # that never happened. KubeClientErrors divides one such bogus rate by another,
+    # which makes it fire at random. It is scoped to job="apiserver", and that is the
+    # only control plane job we can scrape, so turning it off costs no real coverage.
+    # Genuine apiserver problems still page via KubeAPIDown / KubeAPIErrorBudgetBurn.
+    KubeClientErrors: true
+
 nodeExporter:
   resources:
     requests:


### PR DESCRIPTION
`KubeClientErrors` has been firing and resolving at random in `#_bettervoting` for weeks. Nothing is wrong with the cluster — the alert's arithmetic cannot work on AKS. This disables it.

## Why it misfires

AKS runs its apiserver replicas behind one load-balanced endpoint (`20.99.171.51:443`) and doesn't let us scrape them individually, so Prometheus records all of them as a single series. Each replica keeps its own `rest_client_requests_total` counter, and whichever replica the load balancer happens to pick decides what a given scrape sees. When a scrape lands on a replica whose counter is lower than the previous scrape's, Prometheus reads it as a counter reset and books the entire value as new traffic.

`KubeClientErrors` divides one rate built from those samples by another, so it fires on load-balancer luck rather than on errors.

## Evidence from the live cluster

- `process_start_time_seconds{job="apiserver"}` shows exactly **two** replicas alternating scrape by scrape.
- The reported total request rate jumps between near-exact multiples of ~1040/s (1040, 2080, 3120, 4160) — the interleave signature, not real traffic.
- The raw 500 counter only ever reads two values, the replicas' lifetime totals (currently 15 and 17). **Zero new 500s occurred during any firing window.** They're startup noise: a fresh apiserver making internal loopback calls before its aggregated APIs are ready.

Both recent flapping episodes trace to Azure control-plane rolls (07-31 18:13:33/18:14:26 and 08-02 21:08:37/23:31:04), which reset both counters at once. Worth noting the failure mode inverts depending on counter drift: when the two replicas' totals are far apart, the phantom increments land in the *denominator* and suppress the alert; right after a roll they're near-equal and small, so the phantom numerator dominates and it fires steadily. On 07-31 that produced a sustained ~1.6% for hours rather than the usual spiky 10–20% blips.

No workload impact during either roll: zero container restarts, no `KubeAPIDown`, no `TargetDown`, no node events.

## What this costs us

Nothing we actually have. The rule's expression is scoped to `job="apiserver"`, and the other control-plane jobs (`kubeControllerManager`, `kubeScheduler`, `kubeProxy`) are already disabled just above in this file because AKS doesn't expose them — so the apiserver is the only job it could ever cover.

Real apiserver problems still page through `KubeAPIDown` and `KubeAPIErrorBudgetBurn`, neither of which depends on per-replica counter continuity.

Verified against the chart 82.17.1 template, which gates the rule on exactly this key:

```
{{- if not (.Values.defaultRules.disabled.KubeClientErrors | default false) }}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configuration option to disable the `KubeClientErrors` alert by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->