### PR TITLE
Give fider the memory it actually needs

### DIFF
--- a/applications/fider/values.yaml
+++ b/applications/fider/values.yaml
@@ -60,12 +60,21 @@ env:
     value: "sql"
 service:
   port: 3000
+# Fider calls lingua-go for language detection on every post insert
+# (addNewPost -> detectPostLanguage), which lazily loads n-gram models for all
+# 18 locales in enum.AllLocales. Measured on getfider/fider:stable
+# (dev-67c5282): idle 14MB, first insert 3.1s and +338MB, and the models stay
+# resident -- so ~356MB is the real steady state, not a transient spike, and it
+# is reached the moment anyone submits a suggestion. At the old 200Mi limit the
+# pod was OOMKilled mid-request on every first post, which reads to the user as
+# the submit hanging forever. The request matters as much as the limit: at
+# 100Mi the scheduler was sizing this pod at under a third of what it holds.
 resources:
   requests:
     cpu: 10m
-    memory: 100Mi
+    memory: 384Mi
   limits:
-    memory: 200Mi
+    memory: 640Mi
 livenessProbe:
   httpGet:
     port: 3000


### PR DESCRIPTION
Submitting a suggestion on feedback.prod.equal.vote hung forever. The pod was being OOMKilled mid-request — `POST /api/v1/posts started`, then one second later exit 137 with no matching `finished` line, so the browser sat on a dropped connection.

**It isn't per-post overhead.** `addNewPost` calls `detectPostLanguage`, which builds a lingua-go detector over all 18 locales in `enum.AllLocales`. lingua caches its n-gram models package-globally on first use. Reproduced locally against the same image digest (`getfider/fider:stable`, `dev-67c5282`):

| | memory | time |
|---|---|---|
| idle | 14 MB | — |
| POST, title too short (fails early) | 16 MB | 11 ms |
| POST, duplicate title (no insert) | 18 MB | 29 ms |
| **POST, real insert — first one** | **356 MB** | **3103 ms** |
| POST, real insert — second one | 356 MB | 25 ms |

At a 200Mi limit the first insert dies every time. And because the models stay resident, **~356MB is the steady state, not a spike to ride out** — so the old 100Mi request was sizing this pod at under a third of what it holds.

`640Mi` rather than `512Mi` because 356MB is the floor *before* serving any real traffic.

### Capacity

Summing every currently-running pod's worst 7-day working set puts both nodes at ~46% of allocatable, with ~3Gi of headroom each. This lands comfortably.

### Note

The measurement was taken on the amd64 image under emulation; prod nodes are arm64 (`Standard_B2ps_v2`). The models are data-driven so the figure should hold, but worth actually submitting a post after this merges to confirm.

---

Supersedes this PR's original contents (scaling fider to zero), which are obsolete — the `fider-db` cluster has since been rebuilt and fider is serving again.
